### PR TITLE
Fix of syslog

### DIFF
--- a/gitlabitch.rb
+++ b/gitlabitch.rb
@@ -31,7 +31,7 @@ module GitLaBitch
       resource "/#{project}" do
         desc "GitLaBitch #{project} Webhook"
 
-        logger Syslog::Logger.new('gitlabitch', Syslog::LOG_DAEMON)
+        logger Syslog::Logger.new('gitlabitch')
 
         helpers do
           def logger


### PR DESCRIPTION
Generates bullshits, at least on ruby2.0 :

/home/gitlabitch/.rvm/rubies/ruby-2.0.0-p598/lib/ruby/2.0.0/syslog/logger.rb:177:in `initialize': wrong number of arguments (2 for 0..1) (ArgumentError)
